### PR TITLE
Update view-development.adoc

### DIFF
--- a/view-development.adoc
+++ b/view-development.adoc
@@ -286,7 +286,7 @@ Software stack example
 
 ### Performance
 
-IMPORTANT: Requirements are listed in the link:./component-architecture-sizing.adoc[Sizing section].
+IMPORTANT: Requirements are listed in the link:./view-sizing.adoc#requirements[Sizing section].
 
 
 [TIP]


### PR DESCRIPTION
The "sizing requirements" link is broken. I linked it back to the Requirement anchor on the Sizing page